### PR TITLE
Remove gettext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
 FROM django:python2-onbuild
 
-RUN apt-get -qy update && apt-get install -y gettext && rm -rf /var/lib/apt
-
 CMD /bin/sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"


### PR DESCRIPTION
This is only useful for makemessages / compilemessages functionality,
but the additional overhead is not worth it.

Please install gettext locally when that functionality is needed.