### PR TITLE
Remove unnecessary settings for registration app.

### DIFF
--- a/cryptoclass/settings.py
+++ b/cryptoclass/settings.py
@@ -40,7 +40,6 @@ INSTALLED_APPS = (
     'accounts',
     'exercises',
     'bootstrap3',
-    'registration'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -174,7 +173,6 @@ BOOTSTRAP3 = {
 
 # Registration app settings
 
-ACCOUNT_ACTIVATION_DAYS = 30
 REGISTRATION_EMAIL_HTML = True
 REGISTRATION_AUTO_LOGIN = True
 REGISTRATION_OPEN = True


### PR DESCRIPTION
We are using the simple registration backend which doesn't need
registration models, nor REGISTRATION_ACTIVATION_DAYS setting,
since accounts do not need activation.