### PR TITLE
fix /var/lib/apt/lists not empty message during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM django:python2-onbuild
 
-RUN apt-get -qy update && apt-get install -y nginx && rm -rf /var/lib/apt/*
+RUN apt-get -qy update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/* /var/lib/apt/*
 
 COPY nginx.conf /etc/nginx/sites-available/default
 


### PR DESCRIPTION
seems to be a problem between different linux kernels