### PR TITLE
Exercise6 - PGP

### DIFF
--- a/exercises/exercise6/exercise6.py
+++ b/exercises/exercise6/exercise6.py
@@ -1,0 +1,71 @@
+import sys,gnupg,re,subprocess
+import os.path
+
+gpg = gnupg.GPG()
+
+def get_emails(emailString):
+    emailList = re.findall(r"(?<=\<).+(?=\>)", str(emailString))
+    return emailList
+
+def print_info(decrypted):
+    print('User name: %s' % decrypted.username)
+    print('Key id: %s' % decrypted.key_id)
+    print('Signature id: %s' % decrypted.signature_id)
+    print('Signature timestamp: %s' % decrypted.sig_timestamp)
+    print('Fingerprint: %s' % decrypted.fingerprint)
+
+def hasStudentEmail(verified):
+    # XXX: Get studentEmail from some DB
+    studentEmail = "elefthei@Lefs-MacBook-Air.local"
+    emailList = get_emails(verified.username)
+    return studentEmail == emailList[0]
+
+# Assumes lookupMIT works, otherwise I can't fetch the pub key
+def hasAtLeastOneSignature(verified):
+    result = gpg.recv_keys('pgp.mit.edu', verified.key_id)
+    return result.n_sigs > 0
+
+# Assumes lookupMIT works, otherwise I can't fetch the pub key
+def hasExpirationDate(verified):
+    result = gpg.search_keys(verified.key_id, 'pgp.mit.edu')
+    return len(result) > 0 and result[0]['expires']
+
+# Assumes lookupMIT works, otherwise I can't fetch the pub key
+def has4096Length(verified):
+    result = gpg.search_keys(verified.key_id, 'pgp.mit.edu')
+    return len(result) > 0 and result[0]['length'] == '4096'
+
+# Looks up the key id in pgp.mit.edu
+def lookupMIT(verified):
+    result = gpg.search_keys(verified.key_id, 'pgp.mit.edu')
+    return len(result) > 0
+
+def main():
+    if(len(sys.argv)) != 2 or not os.path.isfile(sys.argv[1]):
+        print "Usage: pgpg <SIGNED FILE>"
+
+    stream = open(sys.argv[1], "rb")
+
+    ### DEBUG: Sign file on the fly for testing ####
+    # signed_data = gpg.sign_file(stream)
+
+    verified = gpg.verify_file(stream)
+    lookedup = lookupMIT(verified) 
+    hasStudentEmail = hasStudentEmail(verified)
+    oneSignature = hasAtLeastOneSignature(verified)
+    hasExpiration = hasExpirationDate(verified)
+    has4096 = has4096Length(verified)
+
+    print "Verify Signature: OK" if verified else "Verify Signature: ERROR"
+    print "Look-Up Server MIT: OK" if lookedup else "Look-UP MIT Server: ERROR"
+    print "Has NTUA Student Email: OK" if hasStudentEmail else "Has NTUA Student Email: ERROR"
+    print "Has at least one Signature: OK" if oneSignature else "Has at least one Signature: ERROR"
+    print "Has Expiration Date: OK" if hasExpiration else "Has Expiration Date: ERROR"
+    print "Has length of 4096: OK" if has4096 else "Has length of 4096: ERROR"
+
+    # print_info(verified)
+
+if __name__ == "__main__":
+    main()
+
+

--- a/exercises/exercise6/generators.py
+++ b/exercises/exercise6/generators.py
@@ -1,0 +1,25 @@
+from exercises.registry import register_generator
+
+class PGPExercise(object):
+    '''
+    Hands-on exercise for PGP signing a file
+    '''
+    def __init__(self, args_dict=None):
+        if 'user' not in args_dict:
+            print 'User is required for PGP exercise initialization'
+            exit(1)
+
+        user = args_dict['user']
+
+        if not user.is_authenticated():
+            self.message = 'email@example.com'
+            self.metadata = { }
+            return
+
+        # user is authenticated
+        self.metadata = {
+            'user_email': user.email
+        }
+        self.message = user.email
+
+register_generator('20.0', PGPExercise)

--- a/exercises/exercise6/graders.py
+++ b/exercises/exercise6/graders.py
@@ -34,8 +34,15 @@ def lookupMIT(verified):
     result = gpg.search_keys(verified.key_id, 'pgp.mit.edu')
     return len(result) > 0
 
+# Assumes lookupMIT works, otherwise I can't fetch the pub key
+def importKeyFromData(signed_data):
+    verified = gpg.verify(signed_data)
+    result = gpg.recv_keys(verified.key_id, 'pgp.mit.edu')
+    return
+
 def validate(metadata, signed_data):
 
+    importKeyFromData(signed_data)
     verified = gpg.verify(signed_data)
     lookedup = lookupMIT(verified) 
     hasStudentEmail = hasStudentEmail(verified, metadata['user_email'])

--- a/exercises/exercise6/graders.py
+++ b/exercises/exercise6/graders.py
@@ -1,11 +1,7 @@
-import sys,gnupg,re,subprocess
-import os.path
+import re, sys, gnupg
+from exercises.registry import register_grader
 
 gpg = gnupg.GPG()
-
-def get_emails(emailString):
-    emailList = re.findall(r"(?<=\<).+(?=\>)", str(emailString))
-    return emailList
 
 def print_info(decrypted):
     print('User name: %s' % decrypted.username)
@@ -14,11 +10,9 @@ def print_info(decrypted):
     print('Signature timestamp: %s' % decrypted.sig_timestamp)
     print('Fingerprint: %s' % decrypted.fingerprint)
 
-def hasStudentEmail(verified):
-    # XXX: Get studentEmail from some DB
-    studentEmail = "elefthei@Lefs-MacBook-Air.local"
-    emailList = get_emails(verified.username)
-    return studentEmail == emailList[0]
+def hasStudentEmail(verified, student_email):
+    emailList = re.findall(r"(?<=\<).+(?=\>)", str(verified.username))
+    return student_email in emailList
 
 # Assumes lookupMIT works, otherwise I can't fetch the pub key
 def hasAtLeastOneSignature(verified):
@@ -40,32 +34,17 @@ def lookupMIT(verified):
     result = gpg.search_keys(verified.key_id, 'pgp.mit.edu')
     return len(result) > 0
 
-def main():
-    if(len(sys.argv)) != 2 or not os.path.isfile(sys.argv[1]):
-        print "Usage: pgpg <SIGNED FILE>"
+def validate(metadata, signed_data):
 
-    stream = open(sys.argv[1], "rb")
-
-    ### DEBUG: Sign file on the fly for testing ####
-    # signed_data = gpg.sign_file(stream)
-
-    verified = gpg.verify_file(stream)
+    verified = gpg.verify(signed_data)
     lookedup = lookupMIT(verified) 
-    hasStudentEmail = hasStudentEmail(verified)
+    hasStudentEmail = hasStudentEmail(verified, metadata['user_email'])
     oneSignature = hasAtLeastOneSignature(verified)
     hasExpiration = hasExpirationDate(verified)
     has4096 = has4096Length(verified)
 
-    print "Verify Signature: OK" if verified else "Verify Signature: ERROR"
-    print "Look-Up Server MIT: OK" if lookedup else "Look-UP MIT Server: ERROR"
-    print "Has NTUA Student Email: OK" if hasStudentEmail else "Has NTUA Student Email: ERROR"
-    print "Has at least one Signature: OK" if oneSignature else "Has at least one Signature: ERROR"
-    print "Has Expiration Date: OK" if hasExpiration else "Has Expiration Date: ERROR"
-    print "Has length of 4096: OK" if has4096 else "Has length of 4096: ERROR"
-
     # print_info(verified)
+    return verified and lookedup and hasStudentEmail and oneSignature and hasExpiration and has4096
 
-if __name__ == "__main__":
-    main()
-
+register_grader('20.0', validate)
 


### PR DESCRIPTION
Needs python-gnupg on the server. Run on server:
$ sudo pip install python-gnupg

Assumes signed_data input field exists in front-end, students should copy+paste a clear-signed file in the textfield. Create clear-signed file using:
$ gpg --clearsign FILE
